### PR TITLE
create named export function sendForm, remove default export listeners

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import './styles/main.css'
-import listeners from '@ui/listeners'
+import { sendForm } from '@ui/listeners'
 
 document.addEventListener('DOMContentLoaded', () => {
-    listeners()
+    sendForm()
 })

--- a/src/ui/listeners.js
+++ b/src/ui/listeners.js
@@ -28,4 +28,4 @@ const sendForm = () => {
     )
 }
 
-export default sendForm
+export { sendForm }


### PR DESCRIPTION
Change the default export function to a named export function.