### PR TITLE
Remove the input DOM selector from the listener

### DIFF
--- a/src/ui/listeners.js
+++ b/src/ui/listeners.js
@@ -1,4 +1,4 @@
-import { formFizzBuzz, showErrorsParagraph } from '@ui/selectors'
+import { formFizzBuzz, numberToTest, showErrorsParagraph } from '@ui/selectors'
 import { createEntryObject, saveEntryObject } from '@core/fizzBuzz'
 import printResult from '@ui/printResult'
 
@@ -7,19 +7,14 @@ const sendForm = () => {
         'submit',
         (event) => {
             event.preventDefault()
-
-            let numberToTest = 0
+            let numberReceive = parseInt(numberToTest.value)
             const messageNoNumber = `No has introducido un numero`
 
-            numberToTest = parseInt(
-                document.getElementById('number-to-test').value
-            )
-
-            if (isNaN(numberToTest) || !numberToTest)
+            if (isNaN(numberReceive) || !numberReceive)
                 return (showErrorsParagraph.innerHTML = messageNoNumber)
 
-            saveEntryObject(numberToTest)
-            printResult(createEntryObject(numberToTest))
+            saveEntryObject(numberReceive)
+            printResult(createEntryObject(numberReceive))
             formFizzBuzz.reset()
         },
         false

--- a/src/ui/selectors.js
+++ b/src/ui/selectors.js
@@ -1,5 +1,6 @@
 const formFizzBuzz = document.getElementById('form-fizz-buzz')
+const numberToTest = document.getElementById('number-to-test')
 const displayData = document.getElementById('display-data')
 const showErrorsParagraph = document.getElementById('show-errors')
 
-export { formFizzBuzz, displayData, showErrorsParagraph }
+export { formFizzBuzz, numberToTest, displayData, showErrorsParagraph }


### PR DESCRIPTION
Please keep DOM selectors isolated, as this will help to improve performance and reduce errors.